### PR TITLE
Fix (config) throwing exception when passed no keys

### DIFF
--- a/src/conf_er.clj
+++ b/src/conf_er.clj
@@ -49,10 +49,11 @@
    of nested keys, or no keys at all for the whole map.
 
    Throws an exception if the requested key is not found"
-  [& ks]
-  (if (apply configured? ks)
-    (get-in @config-map ks)
-    (throw (Exception. (str "Could not find " ks " in configuration file")))))
+  ([] @config-map)
+  ([& ks]
+   (if (apply configured? ks)
+     (get-in @config-map ks)
+     (throw (Exception. (str "Could not find " ks " in configuration file"))))))
 
 (defn opt-config
   "Return the requested section of the config map.  Provide any number

--- a/test/test_conf_er.clj
+++ b/test/test_conf_er.clj
@@ -2,13 +2,14 @@
   (:require [midje.sweet :refer :all]
             [conf-er :refer :all]))
 
-(with-redefs [conf-er/config-map (delay
-                                  {:option1 1
-                                   :option2 {:thing :test
-                                             :foo {:bar :baz}}
-                                   :booloptf false
-                                   :booloptt true
-                                   :something nil})]
+(def map {:option1 1
+          :option2 {:thing :test
+                    :foo {:bar :baz}}
+          :booloptf false
+          :booloptt true
+          :something nil})
+
+(with-redefs [conf-er/config-map (delay map)]
   (fact "Basic lookup works"
         (config :option1) => 1
         (config :option2 :thing) => :test
@@ -23,6 +24,9 @@
   (fact "Attempting to get keys which aren't there with strict config throws"
         (config :option2 :thing :bar) => (throws)
         (config :not-there) => (throws))
+
+  (fact "Passing no keys to config returns the whole map"
+        (config) => map)
 
   (fact "Basic lookups return whether they are configured or not"
         (configured? :option1) => true


### PR DESCRIPTION
The docstring of that function says "Provide any number of nested keys, or no
keys at all for the whole map": this commit fixes the second part of the
sentence.
